### PR TITLE
[#40] fix: @Cacheable 자기 호출 문제 해결 및 JVM 메모리 누수 방지

### DIFF
--- a/src/main/java/com/livelihoodcoupon/common/config/RedisConfig.java
+++ b/src/main/java/com/livelihoodcoupon/common/config/RedisConfig.java
@@ -74,6 +74,8 @@ public class RedisConfig {
 				defaultConfig.entryTtl(Duration.ofHours(1))) // 격자 캐시: 1시간
 			.withCacheConfiguration("placeDetails",
 				defaultConfig.entryTtl(Duration.ofMinutes(30))) // 장소 상세: 30분
+			.withCacheConfiguration("placeIds",
+				defaultConfig.entryTtl(Duration.ofHours(2))) // 장소 ID: 2시간
 			.build();
 	}
 }

--- a/src/main/java/com/livelihoodcoupon/place/repository/PlaceRepository.java
+++ b/src/main/java/com/livelihoodcoupon/place/repository/PlaceRepository.java
@@ -27,4 +27,11 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 	 * @return 조회된 Place 엔티티 (Optional)
 	 */
 	Optional<Place> findByPlaceId(String placeId);
+
+	/**
+	 * 카카오 장소 ID가 데이터베이스에 존재하는지 확인합니다.
+	 * @param placeId 확인할 카카오 장소 ID
+	 * @return 존재 여부 (boolean)
+	 */
+	boolean existsByPlaceId(String placeId);
 }

--- a/src/main/java/com/livelihoodcoupon/place/service/PlaceIdCacheService.java
+++ b/src/main/java/com/livelihoodcoupon/place/service/PlaceIdCacheService.java
@@ -4,8 +4,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import jakarta.annotation.PostConstruct;
-
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,22 +23,72 @@ public class PlaceIdCacheService {
 
 	private final PlaceRepository placeRepository;
 	private Set<String> existingPlaceIds;
+	private boolean isBatchMode = false;
 
-	@PostConstruct
-	@Transactional(readOnly = true)
-	public void loadExistingPlaceIds() {
-		log.info("기존 모든 장소 ID를 메모리 캐시에 로드 중...");
+	/**
+	 * 배치 모드 활성화 - 메모리 캐시 사용
+	 */
+	public void enableBatchMode() {
+		log.info("배치 모드 활성화 - 기존 장소 ID를 메모리 캐시에 로드 중...");
 		long startTime = System.currentTimeMillis();
 		existingPlaceIds = Collections.synchronizedSet(new HashSet<>(placeRepository.findAllPlaceIds()));
 		long endTime = System.currentTimeMillis();
 		log.info("{}개의 기존 장소 ID 로드 완료. 소요 시간: {} ms.", existingPlaceIds.size(), (endTime - startTime));
+		isBatchMode = true;
 	}
 
+	/**
+	 * 배치 모드 비활성화 - Redis 캐시 사용
+	 */
+	public void disableBatchMode() {
+		log.info("배치 모드 비활성화 - 메모리 캐시 해제");
+		existingPlaceIds = null;
+		isBatchMode = false;
+	}
+
+	/**
+	 * 장소 ID 존재 여부를 확인합니다.
+	 * 배치 모드일 때는 메모리 캐시를, 일반 모드일 때는 Redis 캐시를 사용합니다.
+	 */
+	@Transactional(readOnly = true)
 	public boolean contains(String placeId) {
-		return existingPlaceIds.contains(placeId);
+		if (isBatchMode && existingPlaceIds != null) {
+			// 배치 모드: 메모리 캐시 사용 (빠름)
+			log.debug("배치 모드 - 메모리 캐시에서 장소 ID 확인: {}", placeId);
+			return existingPlaceIds.contains(placeId);
+		} else {
+			// 일반 모드: Redis 캐시 사용
+			log.debug("일반 모드 - Redis 캐시에서 장소 ID 확인: {}", placeId);
+			return containsWithRedisCache(placeId);
+		}
 	}
 
-	public void add(String placeId) {
-		existingPlaceIds.add(placeId);
+	/**
+	 * Redis 캐시를 사용하여 장소 ID 존재 여부를 확인합니다.
+	 */
+	@Cacheable(value = "placeIds", key = "#placeId", unless = "#result == false")
+	@Transactional(readOnly = true)
+	public boolean containsWithRedisCache(String placeId) {
+		log.debug("Redis 캐시에서 장소 ID 존재 여부 확인: {}", placeId);
+		boolean exists = placeRepository.existsByPlaceId(placeId);
+		log.debug("장소 ID {} 존재 여부: {}", placeId, exists);
+		return exists;
+	}
+
+	/**
+	 * 새로운 장소 ID를 캐시에 추가합니다.
+	 */
+	@CachePut(value = "placeIds", key = "#placeId")
+	public boolean add(String placeId) {
+		if (isBatchMode && existingPlaceIds != null) {
+			// 배치 모드: 메모리 캐시에 추가
+			log.debug("배치 모드 - 메모리 캐시에 장소 ID 추가: {}", placeId);
+			existingPlaceIds.add(placeId);
+			return true;
+		} else {
+			// 일반 모드: Redis 캐시에 추가
+			log.debug("일반 모드 - Redis 캐시에 장소 ID 추가: {}", placeId);
+			return true; // Redis에 true 값으로 저장
+		}
 	}
 }

--- a/src/main/java/com/livelihoodcoupon/place/service/PlaceIdRedisCacheService.java
+++ b/src/main/java/com/livelihoodcoupon/place/service/PlaceIdRedisCacheService.java
@@ -1,0 +1,42 @@
+package com.livelihoodcoupon.place.service;
+
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.livelihoodcoupon.place.repository.PlaceRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Profile("!test")
+public class PlaceIdRedisCacheService {
+
+	private final PlaceRepository placeRepository;
+
+	/**
+	 * Redis 캐시를 사용하여 장소 ID 존재 여부를 확인합니다.
+	 */
+	@Cacheable(value = "placeIds", key = "#placeId", unless = "#result == false")
+	@Transactional(readOnly = true)
+	public boolean contains(String placeId) {
+		log.debug("Redis 캐시에서 장소 ID 존재 여부 확인: {}", placeId);
+		boolean exists = placeRepository.existsByPlaceId(placeId);
+		log.debug("장소 ID {} 존재 여부: {}", placeId, exists);
+		return exists;
+	}
+
+	/**
+	 * 새로운 장소 ID를 Redis 캐시에 추가합니다.
+	 */
+	@CachePut(value = "placeIds", key = "#placeId")
+	public boolean add(String placeId) {
+		log.debug("Redis 캐시에 장소 ID 추가: {}", placeId);
+		return true; // Redis에 true 값으로 저장
+	}
+}


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #1 
- 서브 이슈: #40 

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- 하이브리드 캐시: 배치 모드(메모리) + 일반 모드(Redis)
    - PlaceIdRedisCacheService를 별도 클래스로 분리하여 @Cacheable, @CachePut 어노테이션 등 Spring 프록시 기반 캐시가 정상적으로 작동하도록 보장
- **@PostConstruct 제거로 앱 시작 시 불필요한 메모리 로드 방지 (지연 로딩 방식 적용) (******)**

## 변경 이유
> 왜 이 변경이 필요한지 설명
- Spring의 @Cacheable 어노테이션은 프록시 기반으로 동작하는데, 같은 클래스 내에서 자기 호출할 때는 프록시를 거치지 않아 캐시가 무시되는 문제 발생
- @PostConstruct가 있으면 빈 생성 시 모든 장소 ID를 메모리에 로드하여 메모리 낭비 발생: 
배치 API 호출 시에만 메모리 점유하도록 변경 필요

## 테스트
> 어떤 방법으로 검증했는지 작성
- ./gradlew compileJava로 컴파일 성공 확인
- ./gradlew test로 모든 테스트 통과 확인

## 참고 자료 (선택)
- [Spring Cache Abstraction 공식 문서](https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#cache)
- [Spring AOP 프록시 기반 캐시 동작 원리](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#aop-understanding-aop-proxies)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
- 

## PR 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [x] Swagger / API 문서 반영 완료
