### PR TITLE
[#40] fix: CSV 배치 메모리 누수 해결 및 수동 실행 API 추가

### DIFF
--- a/src/main/java/com/livelihoodcoupon/batch/JobRunner.java
+++ b/src/main/java/com/livelihoodcoupon/batch/JobRunner.java
@@ -1,8 +1,6 @@
 package com.livelihoodcoupon.batch;
 
 import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -18,14 +16,14 @@ import lombok.extern.slf4j.Slf4j;
 public class JobRunner implements CommandLineRunner {
 
 	private final JobLauncher jobLauncher;
-	private final Job csvToDatabaseJob;
+	private final Job placeCsvJob;
 
 	@Override
 	public void run(String... args) throws Exception {
-		log.info("Starting the csvToDatabaseJob");
-		JobParameters jobParameters = new JobParametersBuilder()
-			.addString("JobID", String.valueOf(System.currentTimeMillis()))
-			.toJobParameters();
-		jobLauncher.run(csvToDatabaseJob, jobParameters);
+		// 자동 배치 실행 제거 - 관리자가 필요할 때만 API를 통해 실행
+		log.info("JobRunner 초기화 완료. CSV 배치는 /admin/batch/csv-to-db API를 통해 수동 실행하세요.");
+
+		// 향후 다른 초기화 작업이 필요하면 여기에 추가
+		// 예: 데이터베이스 연결 확인, 캐시 초기화 등
 	}
 }

--- a/src/main/java/com/livelihoodcoupon/batch/PlaceCsvBatchConfig.java
+++ b/src/main/java/com/livelihoodcoupon/batch/PlaceCsvBatchConfig.java
@@ -6,11 +6,8 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
-import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
@@ -33,7 +30,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import com.livelihoodcoupon.place.entity.Place;
 import com.livelihoodcoupon.place.repository.PlaceRepository;
-import com.livelihoodcoupon.place.service.PlaceIdCacheService;
+import com.livelihoodcoupon.place.service.PlaceIdRedisCacheService;
 
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +47,7 @@ public class PlaceCsvBatchConfig {
 	private final EntityManagerFactory entityManagerFactory;
 	private final ResourcePatternResolver resourcePatternResolver; // ResourcePatternResolver 주입
 	private final PlaceRepository placeRepository; // 중복 확인을 위한 PlaceRepository 주입
-	private final PlaceIdCacheService placeIdCacheService; // PlaceIdCacheService 주입
+	private final PlaceIdRedisCacheService placeIdRedisCacheService; // PlaceIdRedisCacheService 주입
 
 	@Bean
 	public Job placeCsvJob() {
@@ -66,20 +63,6 @@ public class PlaceCsvBatchConfig {
 			.reader(multiResourceItemReader(null)) // 초기값은 null, 실제 값은 application.yml에서 로드
 			.processor(placeCsvProcessor())
 			.writer(placeCsvWriter())
-			.listener(new StepExecutionListener() {
-				@Override
-				public void beforeStep(StepExecution stepExecution) {
-					// 배치 시작 시 배치 모드 활성화
-					placeIdCacheService.enableBatchMode();
-				}
-
-				@Override
-				public ExitStatus afterStep(StepExecution stepExecution) {
-					// 배치 완료 시 배치 모드 비활성화
-					placeIdCacheService.disableBatchMode();
-					return stepExecution.getExitStatus();
-				}
-			})
 			.build();
 	}
 
@@ -129,13 +112,13 @@ public class PlaceCsvBatchConfig {
 	@Bean
 	public ItemProcessor<PlaceCsvDto, Place> placeCsvProcessor() {
 		return item -> {
-			// 인메모리 캐시를 사용하여 placeId 중복 확인
-			if (placeIdCacheService.contains(item.getPlaceId())) {
-				log.debug("중복된 placeId (캐시에서): {} 건너뜀", item.getPlaceId());
-				return null; // 캐시에 이미 존재하는 아이템은 건너뜀
+			// Redis 캐시를 사용하여 placeId 중복 확인
+			if (placeIdRedisCacheService.contains(item.getPlaceId())) {
+				log.debug("중복된 placeId (Redis 캐시에서): {} 건너뜀", item.getPlaceId());
+				return null; // Redis 캐시에 이미 존재하는 아이템은 건너뜀
 			}
-			// 새로운 아이템인 경우 캐시에 추가 (현재 배치 내 중복 처리용)
-			placeIdCacheService.add(item.getPlaceId());
+			// 새로운 아이템인 경우 Redis 캐시에 추가
+			placeIdRedisCacheService.add(item.getPlaceId());
 			GeometryFactory geometryFactory = new GeometryFactory();
 			WKTReader wktReader = new WKTReader(geometryFactory);
 			Point point = null;

--- a/src/main/java/com/livelihoodcoupon/batch/controller/BatchController.java
+++ b/src/main/java/com/livelihoodcoupon/batch/controller/BatchController.java
@@ -1,0 +1,106 @@
+package com.livelihoodcoupon.batch.controller;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.livelihoodcoupon.common.exception.ErrorCode;
+import com.livelihoodcoupon.common.response.CustomApiResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 배치 작업 관련 API를 제공하는 컨트롤러
+ *
+ * <h3>주요 기능:</h3>
+ * <ul>
+ *   <li><b>CSV 배치 실행:</b> CSV 파일을 데이터베이스로 로드하는 배치 작업 실행</li>
+ * </ul>
+ *
+ * <h3>API 엔드포인트:</h3>
+ * <ul>
+ *   <li><code>POST /admin/batch/csv-to-db</code> - CSV 파일을 DB로 로드하는 배치 실행</li>
+ * </ul>
+ */
+@Slf4j
+@RestController
+@RequestMapping("/admin/batch")
+@RequiredArgsConstructor
+@Profile("!test")
+public class BatchController {
+
+	private final JobLauncher jobLauncher;
+	private final Job placeCsvJob;
+
+	/**
+	 * CSV 파일을 데이터베이스로 로드하는 배치 작업을 실행합니다.
+	 *
+	 * <p>data/csv/ 디렉토리에 있는 모든 CSV 파일을 읽어서 데이터베이스에 저장합니다.
+	 * Redis 캐시를 사용하여 중복 데이터를 효율적으로 처리합니다.</p>
+	 *
+	 * <p><strong>주의사항:</strong> 이 작업은 대용량 데이터를 처리하므로 완료까지 시간이 걸릴 수 있습니다.
+	 * 배치 작업은 백그라운드에서 비동기적으로 실행됩니다.</p>
+	 *
+	 * @return 배치 작업 시작 성공 메시지
+	 */
+	@PostMapping("/csv-to-db")
+	public ResponseEntity<CustomApiResponse<?>> runCsvToDbBatch() {
+		try {
+			log.info("CSV to DB 배치 작업 시작 요청됨");
+
+			// 배치 작업을 비동기적으로 실행
+			new Thread(() -> {
+				try {
+					JobParameters jobParameters = new JobParametersBuilder()
+						.addString("JobID", String.valueOf(System.currentTimeMillis()))
+						.toJobParameters();
+
+					jobLauncher.run(placeCsvJob, jobParameters);
+					log.info("CSV to DB 배치 작업 완료됨");
+				} catch (Exception e) {
+					log.error("CSV to DB 배치 작업 실행 중 오류 발생", e);
+				}
+			}).start();
+
+			return ResponseEntity.ok(
+				CustomApiResponse.success("CSV to DB 배치 작업이 백그라운드에서 시작되었습니다.")
+			);
+		} catch (Exception e) {
+			log.error("CSV to DB 배치 작업 시작 중 오류 발생", e);
+			return ResponseEntity.internalServerError()
+				.body(CustomApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR,
+					"배치 작업 시작 중 오류가 발생했습니다: " + e.getMessage()));
+		}
+	}
+
+	/**
+	 * 배치 시스템 상태를 확인합니다.
+	 *
+	 * @return 배치 시스템 상태 정보
+	 */
+	@PostMapping("/status")
+	public ResponseEntity<CustomApiResponse<?>> getBatchStatus() {
+		try {
+			log.info("배치 시스템 상태 확인 요청됨");
+
+			return ResponseEntity.ok(
+				CustomApiResponse.success(
+					"배치 시스템이 정상적으로 초기화되었습니다. JobLauncher: " + (
+						jobLauncher != null ? "OK" : "NULL") + ", Job: " + (
+						placeCsvJob != null ? "OK" : "NULL"))
+			);
+		} catch (Exception e) {
+			log.error("배치 시스템 상태 확인 중 오류 발생", e);
+			return ResponseEntity.internalServerError()
+				.body(CustomApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR,
+					"배치 시스템 상태 확인 중 오류가 발생했습니다: " + e.getMessage()));
+		}
+	}
+}


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #40 
- 서브 이슈: #1 

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
-  PlaceCsvBatchConfig에서 메모리 캐시 → Redis 캐시로 변경
- 배치 모드 활성화/비활성화 리스너 제거: 메모리 관리 단순화
- JobRunner에서 자동 배치 실행 제거하고, BatchController로 수동 실행 API 제공
    - `POST` `/admin/batch/csv-to-db` API 제공: 필요할 때만 배치 실행
    - `POST` `/admin/batch/status API` 제공: 배치 시스템 상태 확인 가능

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 앱 시작 시마다 모든 장소 ID를 메모리에 로드하는 메모리 낭비 방지
- CSV 배치는 일회성 작업이므로 필요할 때만 실행하는 것이 효율적
- Redis 캐시 사용으로 메모리 효율성과 성능 확보

## 테스트
> 어떤 방법으로 검증했는지 작성
- 도커 환경에서 배치 시스템 상태 확인 API 테스트 성공
- CSV 배치 수동 실행 API 테스트 성공

## 참고 자료 (선택)
-

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
- 

## PR 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [x] Swagger / API 문서 반영 완료
