### PR TITLE
[#62] feat: 검색 기능 고도화 및 페이징/정렬 로직 개선

### DIFF
--- a/infra/elk/docker-compose.yml
+++ b/infra/elk/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
       - xpack.security.enabled=false
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
     ports:
       - "${ELASTICSEARCH_PORT:-9200}:9200" # HTTP
       - "${ELASTICSEARCH_TRANSPORT_PORT:-9300}:9300" # Transport
@@ -58,11 +62,15 @@ services:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200 # Connect to Elasticsearch service name
     depends_on:
       - elasticsearch # Ensure Elasticsearch is up before Kibana
+    deploy: # 이 섹션을 추가합니다.
+      resources:
+        limits:
+          memory: 1g # Kibana 메모리 제한을 512MB로 설정
     healthcheck:
       test: |
         CMD-SHELL curl -s http://localhost:5601/api/status | grep -q '"state":"green"'
       interval: 10s
-      timeout: 10s
+      timeout: 20s
       retries: 5
       start_period: 30s
     restart: unless-stopped

--- a/src/main/java/com/livelihoodcoupon/common/config/SearchProperties.java
+++ b/src/main/java/com/livelihoodcoupon/common/config/SearchProperties.java
@@ -1,0 +1,16 @@
+package com.livelihoodcoupon.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@ConfigurationProperties(prefix = "search")
+@Getter
+@Setter
+public class SearchProperties {
+	private int pageSize;
+	private int maxResults;
+}

--- a/src/main/java/com/livelihoodcoupon/search/controller/SearchController.java
+++ b/src/main/java/com/livelihoodcoupon/search/controller/SearchController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.livelihoodcoupon.common.config.SearchProperties;
 import com.livelihoodcoupon.common.response.CustomApiResponse;
 import com.livelihoodcoupon.search.dto.AutocompleteDto;
 import com.livelihoodcoupon.search.dto.AutocompleteResponseDto;
@@ -20,6 +21,7 @@ import com.livelihoodcoupon.search.dto.PageResponse;
 import com.livelihoodcoupon.search.dto.PlaceSearchResponseDto;
 import com.livelihoodcoupon.search.dto.SearchRequestDto;
 import com.livelihoodcoupon.search.dto.SearchResponseDto;
+import com.livelihoodcoupon.search.dto.SearchServiceResult;
 import com.livelihoodcoupon.search.service.ElasticService;
 import com.livelihoodcoupon.search.service.SearchService;
 
@@ -34,6 +36,7 @@ public class SearchController {
 
 	private final SearchService search;
 	private final ElasticService elasticService;
+	private final SearchProperties searchProperties;
 
 	/**
 	 * redis 이용한 호출
@@ -48,10 +51,8 @@ public class SearchController {
 		//request 기본 세팅
 		request.initDefaults();
 
-		int maxRecordSize = 100;
-		int pageSize = 10;
-		Page<SearchResponseDto> pageList = search.search(request, pageSize, maxRecordSize);
-		PageResponse<SearchResponseDto> searchResponse = new PageResponse<>(pageList, pageSize);
+		Page<SearchResponseDto> pageList = search.search(request, searchProperties.getPageSize(), searchProperties.getMaxResults());
+		PageResponse<SearchResponseDto> searchResponse = new PageResponse<>(pageList, searchProperties.getPageSize(), request.getLat(), request.getLng());
 
 		return ResponseEntity.ok().body(CustomApiResponse.success(searchResponse));
 
@@ -68,10 +69,9 @@ public class SearchController {
 		//request 기본 세팅
 		request.initDefaults();
 
-		int maxRecordSize = 100;
-		int pageSize = 10;
-		Page<PlaceSearchResponseDto> pageList = elasticService.elasticSearch(request, pageSize, maxRecordSize);
-		PageResponse<PlaceSearchResponseDto> searchResponse = new PageResponse<>(pageList, pageSize);
+		SearchServiceResult result = elasticService.elasticSearch(request, searchProperties.getPageSize(), searchProperties.getMaxResults());
+		Page<PlaceSearchResponseDto> pageList = result.getPage();
+		PageResponse<PlaceSearchResponseDto> searchResponse = new PageResponse<>(pageList, searchProperties.getPageSize(), result.getSearchCenterLat(), result.getSearchCenterLng());
 
 		return ResponseEntity.ok().body(CustomApiResponse.success(searchResponse));
 	}

--- a/src/main/java/com/livelihoodcoupon/search/dto/AnalyzedAddress.java
+++ b/src/main/java/com/livelihoodcoupon/search/dto/AnalyzedAddress.java
@@ -1,0 +1,19 @@
+package com.livelihoodcoupon.search.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnalyzedAddress {
+	private String fullAddress;
+	private String sido;
+	private String sigungu;
+	private List<SearchToken> resultList;
+}

--- a/src/main/java/com/livelihoodcoupon/search/dto/PageResponse.java
+++ b/src/main/java/com/livelihoodcoupon/search/dto/PageResponse.java
@@ -47,7 +47,10 @@ public class PageResponse<T> {
 	//@Schema(description = "끝페이지여부", example = "false")
 	private boolean isLast;
 
-	public PageResponse(Page<T> page, int blockSize) {
+	private double searchCenterLat;
+	private double searchCenterLng;
+
+	public PageResponse(Page<T> page, int blockSize, double searchCenterLat, double searchCenterLng) {
 		this.content = page.getContent();
 		this.currentPage = page.getNumber() + 1;
 
@@ -63,6 +66,8 @@ public class PageResponse<T> {
 		this.blockSize = blockSize;
 		this.isFirst = page.isFirst();
 		this.isLast = page.isLast();
+		this.searchCenterLat = searchCenterLat;
+		this.searchCenterLng = searchCenterLng;
 	}
 
 }

--- a/src/main/java/com/livelihoodcoupon/search/dto/SearchRequestDto.java
+++ b/src/main/java/com/livelihoodcoupon/search/dto/SearchRequestDto.java
@@ -51,6 +51,10 @@ public class SearchRequestDto {
 	@Builder.Default
 	private String sort = "distance";
 
+	//위치 기반 검색 강제 여부 (true일 경우 검색어 내 지역 정보 무시)
+	@Builder.Default
+	private boolean forceLocationSearch = false;
+
 	public void initDefaults() {
 		page = (page == null || page == 0) ? 0 : page;
 		lat = (lat == null || lat == 0.0) ? 37.560949118173454 : lat;

--- a/src/main/java/com/livelihoodcoupon/search/dto/SearchServiceResult.java
+++ b/src/main/java/com/livelihoodcoupon/search/dto/SearchServiceResult.java
@@ -1,0 +1,18 @@
+package com.livelihoodcoupon.search.dto;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Getter;
+
+@Getter
+public class SearchServiceResult {
+	private final Page<PlaceSearchResponseDto> page;
+	private final double searchCenterLat;
+	private final double searchCenterLng;
+
+	public SearchServiceResult(Page<PlaceSearchResponseDto> page, double searchCenterLat, double searchCenterLng) {
+		this.page = page;
+		this.searchCenterLat = searchCenterLat;
+		this.searchCenterLng = searchCenterLng;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,8 @@ elasticsearch:
   host: ${ELASTICSEARCH_HOST:elasticsearch}
   port: ${ELASTICSEARCH_PORT:9200}
   scheme: ${ELASTICSEARCH_SCHEME:http}
+
+# 검색 설정
+search:
+  page-size: 10
+  max-results: 100

--- a/src/test/java/com/livelihoodcoupon/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/livelihoodcoupon/search/controller/SearchControllerTest.java
@@ -31,14 +31,18 @@ import com.livelihoodcoupon.search.dto.AutocompleteResponseDto;
 import com.livelihoodcoupon.search.dto.PlaceSearchResponseDto;
 import com.livelihoodcoupon.search.dto.SearchRequestDto;
 import com.livelihoodcoupon.search.dto.SearchResponseDto;
+import com.livelihoodcoupon.search.dto.SearchServiceResult;
 import com.livelihoodcoupon.search.repository.SearchRepository;
 import com.livelihoodcoupon.search.service.ElasticPlaceService;
 import com.livelihoodcoupon.search.service.ElasticService;
 import com.livelihoodcoupon.search.service.RedisWordRegister;
 import com.livelihoodcoupon.search.service.SearchService;
+import com.livelihoodcoupon.common.config.SearchProperties;
+import org.springframework.context.annotation.Import;
 
 @DisplayName("Search 통합테스트")
 @WebMvcTest(SearchController.class)
+@Import(SearchProperties.class)
 public class SearchControllerTest {
 
 	List<Place> places = null;
@@ -214,7 +218,8 @@ public class SearchControllerTest {
 		List<PlaceSearchResponseDto> searchResponses = List.of(place1);
 		Pageable pageable = PageRequest.of(req.getPage() - 1, 10, Sort.unsorted());
 		Page<PlaceSearchResponseDto> pageList = new PageImpl<>(searchResponses, pageable, 1);
-		when(elasticService.elasticSearch(req, 10, 100)).thenReturn(pageList);
+		SearchServiceResult result = new SearchServiceResult(pageList, req.getLat(), req.getLng());
+		when(elasticService.elasticSearch(req, 10, 100)).thenReturn(result);
 
 		//when
 		ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/livelihoodcoupon/search/service/ElasticPlaceServiceTest.java
+++ b/src/test/java/com/livelihoodcoupon/search/service/ElasticPlaceServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 
+import com.livelihoodcoupon.search.dto.AnalyzedAddress;
 import com.livelihoodcoupon.search.dto.AutocompleteDto;
 import com.livelihoodcoupon.search.dto.AutocompleteResponseDto;
 import com.livelihoodcoupon.search.dto.SearchRequestDto;
@@ -201,7 +202,11 @@ public class ElasticPlaceServiceTest {
 		)).thenReturn(mockResponse);
 
 		// when
-		SearchResponse<PlaceDocument> response = service.searchPlace(tokens, dto, pageable);
+		AnalyzedAddress analyzedAddress = new AnalyzedAddress("", "", "", tokens);
+		dto.setUserLat(37.5665); // Add user coordinates for the new signature
+		dto.setUserLng(126.9780);
+		SearchResponse<PlaceDocument> response = service.searchPlace(analyzedAddress, dto, pageable, dto.getLat(),
+			dto.getLng(), dto.getUserLat(), dto.getUserLng());
 
 		// then
 		assertNotNull(response);

--- a/src/test/java/com/livelihoodcoupon/search/service/ElasticServiceTest.java
+++ b/src/test/java/com/livelihoodcoupon/search/service/ElasticServiceTest.java
@@ -20,8 +20,10 @@ import org.springframework.http.ResponseEntity;
 
 import com.livelihoodcoupon.common.dto.Coordinate;
 import com.livelihoodcoupon.common.service.KakaoApiService;
+import com.livelihoodcoupon.search.dto.AnalyzedAddress;
 import com.livelihoodcoupon.search.dto.PlaceSearchResponseDto;
 import com.livelihoodcoupon.search.dto.SearchRequestDto;
+import com.livelihoodcoupon.search.dto.SearchServiceResult;
 import com.livelihoodcoupon.search.dto.SearchToken;
 import com.livelihoodcoupon.search.entity.PlaceDocument;
 import com.livelihoodcoupon.search.repository.SearchRepository;
@@ -117,13 +119,16 @@ class ElasticServiceTest {
 			.shards(new ShardStatistics.Builder().total(1).successful(1).failed(0).build())
 			.build();
 
-		when(elasticPlaceService.searchPlace(any(), any(), any())).thenReturn(mockResponse);
+		when(elasticPlaceService.searchPlace(any(AnalyzedAddress.class), any(), any(), any(Double.class),
+			any(Double.class), any(Double.class), any(Double.class))).thenReturn(
+			mockResponse);
 		when(searchService.calculateDistance(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
 			.thenReturn(1.23);
 		Coordinate mockCoordinate = new Coordinate(37.5, 127.0);
 
 		//when
-		Page<PlaceSearchResponseDto> page = elasticService.elasticSearch(req, 10, 100);
+		SearchServiceResult result = elasticService.elasticSearch(req, 10, 100);
+		Page<PlaceSearchResponseDto> page = result.getPage();
 
 		//then
 		assertThat(page.getContent())
@@ -204,12 +209,12 @@ class ElasticServiceTest {
 		when(redisService.getWordInfo(anyString())).thenReturn("address");
 
 		// When
-		List<SearchToken> tokens = elasticService.analysisChat(query);
+		AnalyzedAddress analyzedAddress = elasticService.analysisChat(query);
 
 		// Then
-		assertNotNull(tokens);
-		assertEquals(3, tokens.size());
-		assertTrue(tokens.stream().anyMatch(token -> "address".equals(token.getFieldName())));
+		assertNotNull(analyzedAddress);
+		assertEquals(3, analyzedAddress.getResultList().size());
+		assertTrue(analyzedAddress.getResultList().stream().anyMatch(token -> "address".equals(token.getFieldName())));
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈
- 메인 이슈: #62
- 서브 이슈: 없음

## 변경 사항
*   **Elasticsearch 쿼리 로직 재구성**
    *   검색어를 '지역', '카테고리', '일반 키워드'로 분류하여 의미 기반 쿼리 생성
    *   지역/카테고리 키워드는 `must` 절로, 일반 키워드는 `should` 절로 처리
    *   `geo_distance` 필터를 `filter` 절로 이동하여 성능 최적화
*   **페이징 및 정렬 로직 개선**
    *   거리순 정렬 시 사용자 실제 위치를 기준으로 정렬하도록 수정
    *   `max-results`를 초과하는 페이지 요청 시 즉시 빈 페이지 반환 로직 추가
    *   `forceLocationSearch` 플래그를 통한 검색 중심 강제 기능 구현
*   **설정 외부화 및 API 응답 개선**
    *   `page-size`, `max-results` 설정을 `application.yml`로 분리 및 `SearchProperties`로 관리
    *   API 응답(`PageResponse`)에 `searchCenterLat`, `searchCenterLng` 필드 추가
    *   `ElasticService`의 반환 타입을 `SearchServiceResult`로 변경
*   **테스트 코드 업데이트**
    *   변경된 메소드 시그니처, 반환 타입, 설정 주입 방식에 맞춰 모든 관련 테스트 코드 수정

## 변경 이유
*   **검색 정확성 및 사용자 경험 향상:** 사용자의 검색 의도(지역, 카테고리, 일반 키워드)를 더 정확하게 반영하여 관련성 높은 결과를 제공하고, 지도 중심 좌표를 프론트엔드에 제공하여 사용자에게 일관된 지도 경험 제공
*   **시스템 성능 및 안정성 확보:** 불필요한 Elasticsearch 호출을 방지하고, `geo_distance` 필터를 `filter` 절로 옮겨 검색 성능을 최적화
*   **유지보수성 및 유연성 증대:** 페이징 및 검색 관련 설정을 `application.yml`로 외부화하여, 향후 정책 변경 시 코드 수정 없이 설정만으로 대응 가능

## 테스트
*   **단위 테스트:** `ElasticServiceTest`, `ElasticPlaceServiceTest` 등 관련 단위 테스트를 모두 업데이트하고 통과 여부 확인
*   **통합 테스트:** `SearchControllerTest`를 업데이트하고 통과 여부 확인
*   **수동 `curl` 테스트:**
    *   다양한 검색어(예: "카페", "강남 카페", "식당이름")를 사용하여 검색 로직의 정확성 검증
    *   `거리순` 및 `정확도순` 정렬이 의도대로 동작하는지 확인
    *   `max-results` 제한 및 11페이지 조회 시 빈 결과 반환 여부 확인
    *   `forceLocationSearch` 플래그 동작 확인

## 리뷰 요구사항
*   새롭게 재구성된 Elasticsearch 쿼리 로직의 적절성 및 효율성
*   페이징 및 정렬 로직의 정확성
*   `SearchProperties`를 통한 설정 외부화 방식의 적절성

## PR 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [ ] Swagger / API 문서 반영 완료
